### PR TITLE
Clear errors when user tries to submit form

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -103,6 +103,7 @@ class Form {
      */
     submit(requestType, url) {
         this.validateRequestType(requestType);
+        this.errors.clear();
         
         return new Promise((resolve, reject) => {
             axios[requestType](url, this.data())


### PR DESCRIPTION
When user sending form after failed try, it should clear errors before sending request. 