### PR TITLE
Add errors.has check and errors.clear for object names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,14 @@ You find an example implementation with Laravel and Vue in the [spatie/form-back
 ```js
 import Form from 'form-backend-validation';
 
-//instantiate a form class with some value
+// instantiate a form class with some value
 const form = new Form({
     field1: 'value 1',
     field2: 'value 2',
+    person: {
+        first_name: 'John',
+        last_name: 'Doe',
+    },
 });
 
 // a form can also be initiated with an array
@@ -50,21 +54,36 @@ form.post(anUrl)
    .then(response => ...)
    .catch(response => ...);
 
-form.processing; // returns true if request is being executed
+// returns true if request is being executed
+form.processing;
+
 
 // if there were any errors, you can get to them easily
+
+// example errors object
+{ 
+    'field1': ['Value is required'], // single field
+    'person.first_name': ['Value is required'], // field in person object
+}
 
 // returns an object in which the keys are the field names 
 // and the values array with error message sent by the server
 form.errors.all() 
 
-form.errors.any(); // returns true if there were any error
+// returns true if there were any error
+form.errors.any(); 
 
-form.errors.has(fieldName) // return true if there is an error for the given fieldName
+// returns true if there is an error for the given field name or object
+form.errors.has(key)
 
-form.errors.get(fieldName) // return an array with errors for the given fieldName
+// returns an array with errors for the given field name
+form.errors.get(key)
 
-form.errors.clear() // forget all errors.
+// clear all errors
+form.errors.clear()
+
+// clear the error of the given field name or all errors on the given object
+form.errors.clear(key)
 ```
 
 ## Changelog

--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -72,4 +72,24 @@ describe('Errors', () => {
         assert.isFalse(errors.has('first_name'));
         assert.isTrue(errors.has('last_name'));
     });
+
+    it('can clear all errors of a given object', () => {
+        errors.record({
+            'person.first_name': ['Value is required'],
+            'person.last_name': ['Value is required'],
+            'dates.0.start_date': ['Value is required'],
+            'dates.1.start_date': ['Value is required'],
+        });
+
+        errors.clear('person');
+        errors.clear('dates.0');
+
+        assert.isFalse(errors.has('person'));
+        assert.isFalse(errors.has('person.first_name'));
+        assert.isFalse(errors.has('person.last_name'));
+
+        assert.isTrue(errors.has('dates'));
+        assert.isFalse(errors.has('dates.0.start_date'));
+        assert.isTrue(errors.has('dates.1.start_date'));
+    });
 });

--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -25,6 +25,7 @@ describe('Errors', () => {
             'person.0.first_name': ['Value is required'],
         });
         
+        assert.isFalse(errors.has('first'));
         assert.isTrue(errors.has('first_name'));
         assert.isTrue(errors.has('person'));
     });

--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -17,6 +17,18 @@ describe('Errors', () => {
         assert.isTrue(errors.any());
     });
 
+    it('can determine if a given field or object has any errors', () => {
+        assert.isFalse(errors.any());
+
+        errors.record({
+            'first_name': ['Value is required'],
+            'person.0.first_name': ['Value is required'],
+        });
+        
+        assert.isTrue(errors.has('first_name'));
+        assert.isTrue(errors.has('person'));
+    });
+
     it('can get all errors', () => {
         const allErrors = { 'first_name': ['Value is required'] };
 

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -16,12 +16,22 @@ class Errors {
     }
 
     /**
-     * Determine if an errors exists for the given field.
+     * Determine if any errors exists for the given field or object.
      *
      * @param {string} field
      */
     has(field) {
-        return this.errors.hasOwnProperty(field);
+        let hasError = this.errors.hasOwnProperty(field);
+
+        if (!hasError) {
+            const errors = Object.keys(this.errors).filter(e => {
+                return e.startsWith(`${field}.`);
+            });
+
+            hasError = errors.length > 0;
+        }
+
+        return hasError;
     }
 
     /**

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -24,9 +24,9 @@ class Errors {
         let hasError = this.errors.hasOwnProperty(field);
 
         if (!hasError) {
-            const errors = Object.keys(this.errors).filter(e => {
-                return e.startsWith(`${field}.`);
-            });
+            const errors = Object
+                .keys(this.errors)
+                .filter(e => e.startsWith(`${field}.`));
 
             hasError = errors.length > 0;
         }
@@ -62,13 +62,19 @@ class Errors {
     }
 
     /**
-     * Clear one or all error fields.
+     * Clear a specific field, object or all error fields.
      *
      * @param {string|null} field
      */
     clear(field) {
         if (field) {
-            delete this.errors[field];
+            if (this.errors.hasOwnProperty(field)) {
+                delete this.errors[field];
+            } else {
+                Object.keys(this.errors)
+                    .filter(e => e.startsWith(`${field}.`))
+                    .forEach(e => delete this.errors[e]);
+            }
 
             return;
         }

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -67,19 +67,15 @@ class Errors {
      * @param {string|null} field
      */
     clear(field) {
-        if (field) {
-            if (this.errors.hasOwnProperty(field)) {
-                delete this.errors[field];
-            } else {
-                Object.keys(this.errors)
-                    .filter(e => e.startsWith(`${field}.`))
-                    .forEach(e => delete this.errors[e]);
-            }
+        if (! field) {
+            this.errors = {};
 
             return;
         }
 
-        this.errors = {};
+        Object.keys(this.errors)
+              .filter(e => e === field || e.startsWith(`${field}.`))
+              .forEach(e => delete this.errors[e]);
     }
 }
 


### PR DESCRIPTION
Adds the ability to check for errors on any given object (e.g. "person") instead of passing the whole field name (e.g. "person.0.first_name").