### PR TITLE
Allow to use strings instead of Arrays

### DIFF
--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -92,4 +92,13 @@ describe('Errors', () => {
         assert.isFalse(errors.has('dates.0.start_date'));
         assert.isTrue(errors.has('dates.1.start_date'));
     });
+
+    it('can handle errors that returned as string', () => {
+        errors.record({
+            'person.first_name': 'Value is required',
+        });
+
+        assert.isTrue(errors.has('person.first_name'));
+        assert.equal('Value is required', errors.get('person.first_name'));
+    });
 });

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -48,7 +48,7 @@ class Errors {
      */
     get(field) {
         if (this.errors[field]) {
-            if(typeof this.errors[field] === 'string' || this.errors[field] instanceof String) {
+            if(typeof this.errors[field] === 'string') {
                 return this.errors[field];
             }
             return this.errors[field][0];

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -48,6 +48,9 @@ class Errors {
      */
     get(field) {
         if (this.errors[field]) {
+            if(typeof this.errors[field] === 'string' || this.errors[field] instanceof String) {
+                return this.errors[field];
+            }
             return this.errors[field][0];
         }
     }


### PR DESCRIPTION
Now it's impossible to use this package with authorization page because it can return errors in strings instead of arrays.

In PR laravel/framework#18213 there was try to fix this behavior, but Taylor rejected it. So I hope @freekmurze  will help to make this package to work with auth form.

In fact I'm copying behaviour of https://github.com/laravel/framework/blob/5.4/src/Illuminate/Support/MessageBag.php#L151 that is used in auth stub https://github.com/laravel/framework/blob/5.4/src/Illuminate/Auth/Console/stubs/make/views/auth/login.stub#L21