### PR TITLE
Allow errors module to be standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `form-backend-validation` will be documented in this file
 
+## 1.5.1 - 2017-06-17
+- Added: Can now import `Errors` directly as a separate module
+- Added: `Errors` can now accept an object of errors.
+
 ## 1.5.0 - 2017-05-19
 - Added: `options` parameter to `Form`. Currently accepts a `resetOnSuccess` option
 

--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -100,4 +100,18 @@ describe('Errors', () => {
         expect(errors.has('person.first_name')).toBe(true);
         expect(errors.get('person.first_name')).toEqual('Value is required');
     });
+
+    it('can accept an object of errors in its constructor', () => {
+        errors = new Errors({
+            first_name: ['Value is required'],
+        });
+
+        expect(errors.get('first_name')).toEqual('Value is required');
+    });
+
+    it('can assign an empty object in its constructor if no errors are passed', () => {
+        errors = new Errors();
+
+        expect(errors.all()).toEqual({});
+    });
 });

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -2,8 +2,8 @@ class Errors {
     /**
      * Create a new Errors instance.
      */
-    constructor() {
-        this.errors = {};
+    constructor(errors) {
+        this.errors = errors ? errors : {};
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { default as default } from './Form';
+export { default as Errors } from './Errors';


### PR DESCRIPTION
This PR adds the ability to seed a new `Errors` object with results you fetch yourself from the server. This is useful in a Vuex context, where you might be dispatching network requests in actions and wish to mutate the error state through a Vuex mutator.

As a result, this also adds the ability for `Errors` to be used as a stand-alone module.