### PR TITLE
Adds the ability to pass an axios instance into submit

### DIFF
--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -68,8 +68,8 @@ describe('Errors', () => {
 
         errors.clear('first_name');
 
-        expect(errors.has('first_name')).toBe(false)
-        expect(errors.has('last_name')).toBe(true)
+        expect(errors.has('first_name')).toBe(false);
+        expect(errors.has('last_name')).toBe(true);
     });
 
     it('can clear all errors of a given object', () => {

--- a/__tests__/Form.test.js
+++ b/__tests__/Form.test.js
@@ -80,4 +80,22 @@ describe('Errors', () => {
     it('can get an error message for a field', () => {
         expect(form.getError('field1')).toEqual(undefined);
     });
+
+    it('can accept an axios instance in options', () => {
+
+        let instance = axios.create({baseURL: 'http://anotherexample.com'});
+
+        mockAdapter = new MockAdapter(instance);
+
+        form = new Form({}, {axios: instance});
+
+        // @link https://github.com/mzabriskie/axios/issues/737
+        expect(Object.keys(form.getAxios()).reduce((acc, prop) => axios.hasOwnProperty(prop), false)).toBe(true);
+        expect(instance.defaults.baseURL).toBe('http://anotherexample.com');
+
+        form = new Form({});
+        expect(axios === form.getAxios()).toBe(true);
+
+    });
+
 });

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -48,7 +48,7 @@ class Errors {
      */
     get(field) {
         if (this.errors[field]) {
-            if(typeof this.errors[field] === 'string') {
+            if (typeof this.errors[field] === 'string') {
                 return this.errors[field];
             }
             return this.errors[field][0];

--- a/src/Form.js
+++ b/src/Form.js
@@ -9,7 +9,6 @@ class Form {
      * @param {object} options
      */
     constructor(data, options) {
-
         if (Array.isArray(data)) {
             data = data.reduce((carry, element) => {
                 carry[element] = '';
@@ -25,7 +24,7 @@ class Form {
             this[field] = data[field];
         }
 
-        this.__options = { 
+        this.__options = {
             resetOnSuccess: true,
             ...options,
         };
@@ -108,13 +107,13 @@ class Form {
      * @param {string} requestType
      * @param {string} url
      */
-    submit(requestType, url) {
+    submit(requestType, url, ajax = axios) {
         this.validateRequestType(requestType);
         this.errors.clear();
         this.processing = true;
 
         return new Promise((resolve, reject) => {
-            axios[requestType](url, this.data())
+            ajax[requestType](url, this.data())
                 .then((response) => {
                     this.processing = false;
                     this.onSuccess(response.data);
@@ -132,12 +131,12 @@ class Form {
 
     /**
      * Validate a request type.
-     * 
+     *
      * @param {string} requestType
      */
     validateRequestType(requestType) {
         const requestTypes = ['get', 'delete', 'head', 'post', 'put', 'patch'];
-        
+
         if (requestTypes.indexOf(requestType) === -1) {
             throw new Error(`\`${requestType}\` is not a valid request type, ` +
                 `must be one of: \`${requestTypes.join('\`, \`')}\`.`);

--- a/src/Form.js
+++ b/src/Form.js
@@ -30,6 +30,17 @@ class Form {
         };
     }
 
+   /*
+    * getAxios
+    * retrieves axios, favouring the injected version if present.
+    * @return axios
+    */
+    getAxios() {
+      let options = this.__options;
+      return options.hasOwnProperty('axios') ? options.axios : axios;
+    }
+
+
     /**
      * Fetch all relevant data for the form.
      */
@@ -107,13 +118,15 @@ class Form {
      * @param {string} requestType
      * @param {string} url
      */
-    submit(requestType, url, ajax = axios) {
+    submit(requestType, url) {
         this.validateRequestType(requestType);
         this.errors.clear();
         this.processing = true;
 
+        let axios = this.getAxios();
+
         return new Promise((resolve, reject) => {
-            ajax[requestType](url, this.data())
+            axios[requestType](url, this.data())
                 .then((response) => {
                     this.processing = false;
                     this.onSuccess(response.data);


### PR DESCRIPTION
This PR allows the axios library to be pre-configured.
Example:

```
export const commonAxiosApi = axios.create({
  baseURL: A_BASE_URL,
  headers: {
    'Authorization': 'Bearer ' + A_TOKEN_THATS_SET
  }
})

// later in a Vue component

async onSubmit () {
  try {
          let response = await this.form.post(this.form.action, commonAxiosApi)
  // go to town
  } catch (err) {
        // failville
  }
},
```

By doing so would allow axios instances to switched in. Default parameter means it won't break exisiting implementations.




