### PR TITLE
Add support for array errors

### DIFF
--- a/src/Errors.js
+++ b/src/Errors.js
@@ -26,7 +26,7 @@ class Errors {
         if (! hasError) {
             const errors = Object
                 .keys(this.errors)
-                .filter(e => e.startsWith(`${field}.`));
+                .filter(e => e.startsWith(`${field}.`) || e.startsWith(`${field}[`));
 
             hasError = errors.length > 0;
         }


### PR DESCRIPTION
`documents[0].file` was not picked up when calling `errors.has('documents')`.