### PR TITLE
Fix: axios global headers not being sent

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -62,7 +62,7 @@ class Form {
             this.onFail = options.onFail;
         }
 
-        this.__http = options.http || require('axios');
+        this.__http = options.http || window.axios || require('axios');
 
         if (! this.__http) {
             throw new Error('No http library provided. Either pass an http option, or install axios.');


### PR DESCRIPTION
If you update axios to v0.17.0 you will notice that axios global headers are not being sent.

```js
// bootstrap.js
window.axios = require('axios');
// global headers
axios.defaults.headers.common['X-CSRF-TOKEN'] = window.appConfig.csrfToken;
axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
```
Laravel is throwing 419 when csrf-token not found.

**P.S** It would be nice if you can release a patch for v1.8 as well.