### PR TITLE
Add a method to populate the form

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ yarn add axios
 
 ## Usage
 
-You find an example implementation with Laravel and Vue in the [spatie/form-backend-validation-example-app repo](https://github.com/spatie/form-backend-validation-example-app). 
+You find an example implementation with Laravel and Vue in the [spatie/form-backend-validation-example-app repo](https://github.com/spatie/form-backend-validation-example-app).
 
 ![Screenshot](https://raw.githubusercontent.com/spatie/form-backend-validation-example-app/master/public/images/screenshot.png)
 
@@ -65,7 +65,7 @@ form.processing;
     }
 }
 
-// Returns an object in which the keys are the field names 
+// Returns an object in which the keys are the field names
 // and the values array with error message sent by the server
 form.errors.all();
 
@@ -96,6 +96,17 @@ form.reset();
 
 // Set the values which should be used when calling reset()
 form.setInitialValues();
+
+// Populate a form after its instantiation, the populated fields won't override the initial fields
+// Fields not present at instantiation will not be populated
+const form = new Form({
+    field1: '',
+    field2: '',
+});
+form.populate({
+    field1: 'foo',
+    field2: 'bar',
+});
 
 ```
 
@@ -181,7 +192,7 @@ The idea to go about this way of validating forms comes from [Laravel Spark](htt
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/__tests__/Form.test.js
+++ b/__tests__/Form.test.js
@@ -4,6 +4,12 @@ import axios from 'axios';
 
 let form;
 let mockAdapter;
+const reservedFieldNames = [
+    '__http', '__options', '__validateRequestType', 'clear', 'data',
+    'delete', 'errors', 'getError', 'getErrors', 'hasError', 'initial',
+    'onFail', 'onSuccess', 'patch', 'post', 'processing', 'put',
+    'reset', 'submit', 'withData', 'withErrors', 'withOptions',
+];
 
 describe('Errors', () => {
 
@@ -81,15 +87,30 @@ describe('Errors', () => {
     });
 
     it('can\'t be initialized with a reserved field name', () => {
-        const reservedFieldNames = [
-            '__http', '__options', '__validateRequestType', 'clear', 'data',
-            'delete', 'errors', 'getError', 'getErrors', 'hasError', 'initial',
-            'onFail', 'onSuccess', 'patch', 'post', 'processing', 'put',
-            'reset', 'submit', 'withData', 'withErrors', 'withOptions',
-        ];
-
         reservedFieldNames.forEach(fieldName => {
             expect(() => new Form({ [fieldName]: 'foo' })).toThrow();
+        });
+    });
+
+    it('can be populated with an object', () => {
+        form = new Form({ field: ''});
+
+        form.populate({field: 'foo'});
+
+        expect(form.field).toBe('foo');
+    });
+
+    it('can\'t be populated with fields not present during instantiation', () => {
+        form = new Form({ field: ''});
+
+        form.populate({field: 'foo', anotherField: 'baz'});
+
+        expect(form.anotherField).toBe(undefined);
+    });
+
+    it('can\'t be populated with a reserved field name', () => {
+        reservedFieldNames.forEach(fieldName => {
+            expect(() => new Form().populate({ [fieldName]: 'foo' })).toThrow();
         });
     });
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -107,6 +107,8 @@ class Form {
                 this[field] = data[field];
             }
         });
+        
+        return this;
     }
 
     /**

--- a/src/Form.js
+++ b/src/Form.js
@@ -99,6 +99,16 @@ class Form {
         merge(this.initial, values);
     }
 
+    populate(data) {
+        Object.keys(data).forEach((field) => {
+            guardAgainstReservedFieldName(field);
+
+            if (this.hasOwnProperty(field)) {
+                this[field] = data[field];
+            }
+        });
+    }
+
     /**
      * Clear the form fields.
      */


### PR DESCRIPTION
I'm using the same form to create and update.
With the populate method it's easy to setup a form with initials values and populate it afterwards.
Calling form.reset() will still restore the fields to their initial values.