### PR TITLE
add successful state property

### DIFF
--- a/__tests__/Form.test.js
+++ b/__tests__/Form.test.js
@@ -84,7 +84,7 @@ describe('Errors', () => {
         const reservedFieldNames = [
             '__http', '__options', '__validateRequestType', 'clear', 'data',
             'delete', 'errors', 'getError', 'getErrors', 'hasError', 'initial',
-            'onFail', 'onSuccess', 'patch', 'post', 'processing', 'put',
+            'onFail', 'onSuccess', 'patch', 'post', 'processing', 'successful', 'put',
             'reset', 'submit', 'withData', 'withErrors', 'withOptions',
         ];
 
@@ -138,6 +138,16 @@ describe('Errors', () => {
         form.errors.record({ field1: ['Value is required'] });
 
         expect(form.hasError('field1')).toBe(true);
+    });
+
+    it('can be successfully completed', async () => {
+        mockAdapter.onPost('http://example.com/posts').reply(200, {});
+
+        form = new Form();
+
+        await form.submit('post', 'http://example.com/posts');
+
+        expect(form.successful).toBe(true);
     });
 
     it('can get an error message for a field', () => {

--- a/src/Form.js
+++ b/src/Form.js
@@ -11,6 +11,7 @@ class Form {
      */
     constructor(data = {}, options = {}) {
         this.processing = false;
+        this.successful = false;
 
         this.withData(data)
             .withOptions(options)
@@ -29,6 +30,7 @@ class Form {
 
         this.errors = new Errors();
         this.processing = false;
+        this.successful = false;
 
         for (const field in data) {
             guardAgainstReservedFieldName(field);
@@ -156,6 +158,7 @@ class Form {
         this.__validateRequestType(requestType);
         this.errors.clear();
         this.processing = true;
+        this.successful = false;
 
         return new Promise((resolve, reject) => {
             this.__http[requestType](url, this.data())
@@ -180,6 +183,8 @@ class Form {
      * @param {object} data
      */
     onSuccess(data) {
+        this.successful = true;
+
         if (this.__options.resetOnSuccess) {
             this.reset();
         }
@@ -191,6 +196,8 @@ class Form {
      * @param {object} data
      */
     onFail(error) {
+        this.successful = false;
+
         if (error.response && error.response.data.errors) {
             this.errors.record(error.response.data.errors);
         }

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ export function isArray(object) {
 const reservedFieldNames = [
     '__http', '__options', '__validateRequestType', 'clear', 'data', 'delete',
     'errors', 'getError', 'getErrors', 'hasError', 'initial', 'onFail',
-    'onSuccess', 'patch', 'post', 'processing', 'put', 'reset', 'submit',
+    'onSuccess', 'patch', 'post', 'processing', 'successful', 'put', 'reset', 'submit',
     'withData', 'withErrors', 'withOptions',
 ];
 


### PR DESCRIPTION
This PR adds a `successful` like Laravel Sparks Form module has it. It is quite helpful to receive this state info from the form itself because it removes the need to add your own success property or extra logic after the request has been completed if that logic would be something as simple as showing an alert.

```html
<div class="alert" v-if="form.successful">
    Your contact information has been updated!
</div>

<button class="button" @click.prevent="update" :disabled="form.processing">
    Update
</button>
```