### PR TITLE
Errors.clear() supports array key parameter

### DIFF
--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -78,10 +78,13 @@ describe('Errors', () => {
             'person.last_name': ['Value is required'],
             'dates.0.start_date': ['Value is required'],
             'dates.1.start_date': ['Value is required'],
+            'roles[0].name':  ['Value is required'],
+            'roles[1].name':  ['Value is required'],
         });
 
         errors.clear('person');
         errors.clear('dates.0');
+        errors.clear('roles[1]');
 
         expect(errors.has('person')).toBe(false);
         expect(errors.has('person.first_name')).toBe(false);
@@ -90,6 +93,10 @@ describe('Errors', () => {
         expect(errors.has('dates')).toBe(true);
         expect(errors.has('dates.0.start_date')).toBe(false);
         expect(errors.has('dates.1.start_date')).toBe(true);
+
+        expect(errors.has('roles')).toBe(true);
+        expect(errors.has('roles[0].name')).toBe(true);
+        expect(errors.has('roles[1].name')).toBe(false);
     });
 
     it('can accept an object of errors in its constructor', () => {

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -9,7 +9,7 @@ class Errors {
     /**
      * Get all the errors.
      *
-     * @param {object} errors
+     * @return {object}
      */
     all() {
         return this.errors;
@@ -71,7 +71,7 @@ class Errors {
         }
 
         Object.keys(this.errors)
-              .filter(e => e === field || e.startsWith(`${field}.`))
+              .filter(e => e === field || e.startsWith(`${field}.`) || e.startsWith(`${field}[`))
               .forEach(e => delete this.errors[e]);
     }
 }


### PR DESCRIPTION
This makes `clear()` match `Errors.has()` changes made in https://github.com/spatie/form-backend-validation/pull/29

```javascript
const errors = new Errors({
    'documents[0].file': ['Upload limit is 5MB.'],
    'documents[1].file': ['This is clearly a .exe trojan. Shame on you.'],
});

errors.has('documents[1].file'); // true
errors.clear('documents[1]');
errors.has('documents'); // true
errors.has('documents[1].file'); // false
```

I also corrected the JSDoc of `Errors.all()`