### PR TITLE
Ensure clearing an error is done reactively

### DIFF
--- a/src/Errors.js
+++ b/src/Errors.js
@@ -69,10 +69,14 @@ class Errors {
 
             return;
         }
+        
+        let errors = Object.assign({}, this.errors);
 
-        Object.keys(this.errors)
+        Object.keys(errors)
             .filter(e => e === field || e.startsWith(`${field}.`) || e.startsWith(`${field}[`))
-            .forEach(e => delete this.errors[e]);
+            .forEach(e => delete errors[e]);
+        
+        this.errors = errors;
     }
 }
 


### PR DESCRIPTION
Deletions on objects in Javascript can not be detected in Vue.js. So to enable use of the errors library reactively we need to clone and replace the errors collection.

This fixes an issue I'm currently encountering where running `form.errors.clear('fieldName');` has no effect inside my Vue.js application because the change isn't reactive.