### PR TITLE
Add support for passing an optional array to errors.any()

### DIFF
--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -16,11 +16,17 @@ describe('Errors', () => {
     });
 
     it('can determine if a given array has any errors', () => {
-        expect(errors.any(['first_name'])).toBe(false);
+        expect(errors.any(['first_name', 'last_name', 'email'])).toBe(false);
 
         errors.record({ first_name: ['Value is required'] });
 
         expect(errors.any(['first_name'])).toBe(true);
+
+        errors.record({ first_name: ['Value is required'], last_name: ['Value is required'] });
+
+        expect(errors.any(['email'])).toBe(false);
+        
+        expect(errors.any(['email', 'last_name'])).toBe(true);
     });
 
     it('can determine if a given field or object has any errors', () => {

--- a/__tests__/Errors.test.js
+++ b/__tests__/Errors.test.js
@@ -15,6 +15,14 @@ describe('Errors', () => {
         expect(errors.any()).toBe(true);
     });
 
+    it('can determine if a given array has any errors', () => {
+        expect(errors.any(['first_name'])).toBe(false);
+
+        errors.record({ first_name: ['Value is required'] });
+
+        expect(errors.any(['first_name'])).toBe(true);
+    });
+
     it('can determine if a given field or object has any errors', () => {
         expect(errors.any()).toBe(false);
 

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -46,13 +46,17 @@ class Errors {
      * Determine if we have any errors.
      */
     any(keys = null) {
+        let hasError = false;
+
         if (Array.isArray(keys)) {
-            keys.forEach((key) => {
+            hasError = keys.some((key) => {
                 return this.has(key);
             });
+        } else {
+            hasError = Object.keys(this.errors).length > 0;
         }
 
-        return Object.keys(this.errors).length > 0;
+        return hasError;
     }
 
     /**

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -45,7 +45,13 @@ class Errors {
     /**
      * Determine if we have any errors.
      */
-    any() {
+    any(keys = null) {
+        if (Array.isArray(keys)) {
+            keys.forEach((key) => {
+                return this.has(key);
+            });
+        }
+
         return Object.keys(this.errors).length > 0;
     }
 


### PR DESCRIPTION
This pull request allows you to pass an array to `errors.any()`
Resolves issue #54 