### PR TITLE
Support array of objects deep cloning

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -1,5 +1,5 @@
 import Errors from './Errors';
-import { guardAgainstReservedFieldName, isArray, merge, objectToFormData } from './util';
+import { guardAgainstReservedFieldName, isArray, isFile, merge, objectToFormData } from './util';
 
 class Form {
     /**
@@ -206,14 +206,47 @@ class Form {
         });
     }
 
+    /**
+     * @returns {boolean}
+     */
     hasFiles() {
         for (const property in this.initial) {
-            if (this[property] instanceof File || this[property] instanceof FileList) {
+            if (this.hasFilesDeep(this[property])) {
                 return true;
             }
         }
 
         return false;
+    };
+
+    /**
+     * @param {Object|Array} object
+     * @returns {boolean}
+     */
+    hasFilesDeep(object) {
+        if (object === null) {
+            return false;
+        }
+
+        if (typeof object === 'object') {
+            for (const key in object) {
+                if (object.hasOwnProperty(key)) {
+                    if (isFile(object[key])) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (Array.isArray(object)) {
+            for (const key in object) {
+                if (object.hasOwnProperty(key)) {
+                    return this.hasFilesDeep(object[key]);
+                }
+            }
+        }
+
+        return isFile(object);
     }
 
     /**

--- a/src/util/objects.js
+++ b/src/util/objects.js
@@ -2,6 +2,10 @@ export function isArray(object) {
     return Object.prototype.toString.call(object) === '[object Array]';
 }
 
+export function isFile(object) {
+    return object instanceof File || object instanceof FileList;
+}
+
 export function merge(a, b) {
     for (const key in b) {
         a[key] = cloneDeep(b[key]);
@@ -13,8 +17,20 @@ export function cloneDeep(object) {
         return null;
     }
 
+    if (isFile(object)) {
+        return object;
+    }
+
     if (Array.isArray(object)) {
-        return [...object];
+        const clone = [];
+
+        for (const key in object) {
+            if (object.hasOwnProperty(key)) {
+                clone[key] = cloneDeep(object[key]);
+            }
+        }
+
+        return clone;
     }
 
     if (typeof object === 'object') {


### PR DESCRIPTION
1) Fix deep array cloning by replacing shallow copying with a recursive call to `cloneDeep`.
2) Change `hasFiles` to look deeper for File existence.