### PR TITLE
Check for window before trying to access axios, because of nuxt ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `form-backend-validation` will be documented in this file
 
+## 2.3.3 - 2018-12-13
+- Changed: Checks now for the existence of window before trying to access axios of it
+
 ## 2.3.3 - 2018-03-27
 - Changed: Updated errors are now mutated instead of reassigned (fixes reactivity caveats)
 

--- a/src/Form.js
+++ b/src/Form.js
@@ -63,7 +63,9 @@ class Form {
             this.onFail = options.onFail;
         }
 
-        this.__http = options.http || window.axios || require('axios');
+        const windowAxios = typeof window === 'undefined' ? false : window.axios
+
+        this.__http = options.http || windowAxios || require('axios');
 
         if (!this.__http) {
             throw new Error(


### PR DESCRIPTION
Hi guys,

Because of ssr while using nuxt you get a window is not defined error if you use it out of the box in the data section of a component and make a hard refresh. 

One possibility to avoid this issue is to use a plugin, inject it as a property on the vue instance and add the plugin with ssr=false. This get's rid of the error but then you can't call a function in the data section (like .withData()) on it because it's undefined on the server.

This pr just checks if the window is defined before trying to access axios. This tiny change makes it's possible to just use it out of the box with nuxt.