### PR TITLE
Fix omitted empty values on submit

### DIFF
--- a/src/util/formData.js
+++ b/src/util/formData.js
@@ -1,4 +1,8 @@
 export function objectToFormData(object, formData = new FormData(), parent = null) {
+    if (object === null || object === 'undefined' || object.length === 0) {
+        return formData.append(parent, object);
+    }
+
     for (const property in object) {
         if (object.hasOwnProperty(property)) {
             appendToFormData(formData, getKey(parent, property), object[property]);


### PR DESCRIPTION
When there is at least one File in the form, keys holding the files and being empty are omitted from the posted data. In contrast, if there is no files at all, keys with empty values are included in the posted data.

This inconsistency is due to `objectToFormData` not appending the keys holding empty values. Eg when `object[property]` evaluates to `[]`.

 This bug has major effect on data been validated at the backend. 