### PR TITLE
convert boolean values to 1 or 0 when using FormData

### DIFF
--- a/__tests__/Form.test.js
+++ b/__tests__/Form.test.js
@@ -287,6 +287,32 @@ describe('Form', () => {
 
         await form.submit('post', 'http://example.com/posts');
     });
+
+    it('transforms the boolean values in FormData object to "1" or "0"', async () => {
+        const file = new File(['hello world!'], 'myfile');
+
+        form.field1 = {
+            foo: true,
+            bar: false
+        };
+        form.field2 = file;
+
+        mockAdapter.onPost('http://example.com/posts').reply(request => {
+            expect(request.data).toBeInstanceOf(FormData);
+                expect(request.data.get('field1[foo]')).toBe('1');
+            expect(request.data.get('field1[bar]')).toBe('0');
+            expect(request.data.get('field2')).toEqual(file);
+
+            expect(getFormDataKeys(request.data)).toEqual([
+                'field1[foo]',
+                'field1[bar]',
+                'field2',
+            ]);
+            return [200, {}];
+        });
+
+        await form.submit('post', 'http://example.com/posts');
+    });
 });
 
 function getFormDataKeys(formData) {

--- a/src/util/formData.js
+++ b/src/util/formData.js
@@ -25,6 +25,10 @@ function appendToFormData(formData, key, value) {
         return formData.append(key, value, value.name);
     }
 
+    if (typeof value === "boolean") {
+        return formData.append(key, value ? '1' : '0');
+    }
+
     if (typeof value !== 'object') {
         return formData.append(key, value);
     }


### PR DESCRIPTION
`boolean` values are converted to their string representations (`"true"` and `"false"`) when the data object is converted to `FormData`. This causes Laravel's [boolean](https://laravel.com/docs/master/validation#rule-boolean) validation rule to fail.

The proposed update would allow for these values to be converted to `1` or `0` to allow the validation to pass or fail correctly.