### PR TITLE
Convert null to empty strings when using FormData

### DIFF
--- a/src/util/formData.js
+++ b/src/util/formData.js
@@ -29,6 +29,10 @@ function appendToFormData(formData, key, value) {
         return formData.append(key, value ? '1' : '0');
     }
 
+    if (value === null) {
+        return formData.append(key, '');
+    }
+    
     if (typeof value !== 'object') {
         return formData.append(key, value);
     }


### PR DESCRIPTION
Now null values converts into strings 'null'. This pull request fixes it