### PR TITLE
Fix passing form data on delete requests

### DIFF
--- a/__tests__/Form.test.js
+++ b/__tests__/Form.test.js
@@ -313,6 +313,28 @@ describe('Form', () => {
 
         await form.submit('post', 'http://example.com/posts');
     });
+
+    it('sends form data on delete requests', async () => {
+        const file = new File(['hello world!'], 'myfile');
+
+        form.field1 = 'foo';
+        form.field2 = file;
+
+        mockAdapter.onDelete('http://example.com/posts').reply(request => {
+            expect(request.data).toBeDefined();
+            expect(request.data).toBeInstanceOf(FormData);
+            expect(request.data.get('field1')).toBe('foo');
+            expect(request.data.get('field2')).toEqual(file);
+
+            expect(getFormDataKeys(request.data)).toEqual([
+                'field1',
+                'field2'
+            ]);
+            return [200, {}];
+        });
+
+        await form.submit('delete', 'http://example.com/posts');
+    });
 });
 
 function getFormDataKeys(formData) {

--- a/src/Form.js
+++ b/src/Form.js
@@ -189,10 +189,11 @@ class Form {
         this.successful = false;
 
         return new Promise((resolve, reject) => {
-            this.__http[requestType](
+            this.__http.request({
                 url,
-                this.hasFiles() ? objectToFormData(this.data()) : this.data()
-            )
+                method: requestType,
+                data: this.hasFiles() ? objectToFormData(this.data()) : this.data(),
+            })
                 .then(response => {
                     this.processing = false;
                     this.onSuccess(response.data);


### PR DESCRIPTION
Currently when using `form.delete('<url>')` the form data isn't actually sent to the server. This PR fixes this by using the `request` method from axios to explicitly pass the data to the request.

This does introduce a breaking change for people using a custom HTTP library, although I expect most users to use axios. Let me know if you want me to add a workaround to still support other HTTP libraries, e.g. by including a check to see if the `this.__http.request` is callable, and falling back to the old behavior if it isn't.