### PR TITLE
Form doesn't scan deeply nested objects

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -233,7 +233,7 @@ class Form {
         if (typeof object === 'object') {
             for (const key in object) {
                 if (object.hasOwnProperty(key)) {
-                    if (isFile(object[key])) {
+                    if (this.hasFilesDeep(object[key])) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Fixes the form data not being able to find files in deeply nested objects. Instead of iterating over the properties only, it'll deeply scan objects too. Sometimes you need specific keys in forms, so this way files can be found.