### PR TITLE
Fix documentation of `form.getError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ form.errors.first(key);
 // Returns an array with errors for the given field name
 form.errors.get(key);
 
-// Shortcut for getting the errors for the given field name
+// Shortcut for getting the first error for the given field name
 form.getError(key);
 
 // Clear all errors


### PR DESCRIPTION
The `form.getError` method is actually a shortcut for `form.errors.first`, not `form.errors.get`, so this comment should indicate that it will return one error message rather than an array of many.

https://github.com/spatie/form-backend-validation/blob/a5026df8c3a3bf610e52d3080945f025db8de4a4/src/Form.js#L289-L297